### PR TITLE
corección bug tablero

### DIFF
--- a/movil/.idea/deploymentTargetSelector.xml
+++ b/movil/.idea/deploymentTargetSelector.xml
@@ -4,10 +4,10 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2026-04-30T12:00:40.588628600Z">
+        <DropdownSelection timestamp="2026-05-01T10:48:47.765899Z">
           <Target type="DEFAULT_BOOT">
             <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\serfo\.android\avd\Medium_Phone_2.avd" />
+              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/ropinbet/.android/avd/Pixel_6.avd" />
             </handle>
           </Target>
         </DropdownSelection>

--- a/movil/app/src/main/java/com/example/bombavafrontmovil/BoardAdapter.java
+++ b/movil/app/src/main/java/com/example/bombavafrontmovil/BoardAdapter.java
@@ -108,24 +108,27 @@ public class BoardAdapter extends RecyclerView.Adapter<BoardAdapter.ViewHolder> 
         if (c.isTieneBarco() && c.isVisible() && c.getVidaActual() > 0) {
             vh.imgBarco.setVisibility(View.VISIBLE);
 
-            boolean esPiezaInicial = (c.getIndiceEnBarco() == 0 && c.getTipoBarco() > 1);
-            boolean esVertical = (c.getDireccion() == 0 || c.getDireccion() == 2);
             boolean barcoRoto = c.getVidaMax() > 0 && c.getVidaActual() <= (c.getVidaMax() / 2);
+            boolean esExtremoInicial = (c.getIndiceEnBarco() == 0 && c.getTipoBarco() > 1);
+            boolean esExtremoFinal = c.isEsProa();
+            boolean esVertical = (c.getDireccion() == 0 || c.getDireccion() == 2);
 
             int resId;
 
-            if (esVertical) {
-                if (c.isEsProa()) {
+            if (c.getTipoBarco() <= 1) {
+                resId = barcoRoto ? R.drawable.barco_medio_roto : R.drawable.barco_medio;
+            } else if (esVertical) {
+                if (esExtremoFinal) {
                     resId = barcoRoto ? R.drawable.barco_popa_roto : R.drawable.barco_popa;
-                } else if (esPiezaInicial) {
+                } else if (esExtremoInicial) {
                     resId = barcoRoto ? R.drawable.barco_proa_roto : R.drawable.barco_proa;
                 } else {
                     resId = barcoRoto ? R.drawable.barco_medio_roto : R.drawable.barco_medio;
                 }
             } else {
-                if (c.isEsProa()) {
+                if (esExtremoFinal) {
                     resId = barcoRoto ? R.drawable.barco_proa_roto : R.drawable.barco_proa;
-                } else if (esPiezaInicial) {
+                } else if (esExtremoInicial) {
                     resId = barcoRoto ? R.drawable.barco_popa_roto : R.drawable.barco_popa;
                 } else {
                     resId = barcoRoto ? R.drawable.barco_medio_roto : R.drawable.barco_medio;

--- a/movil/app/src/main/java/com/example/bombavafrontmovil/GestorJuego.java
+++ b/movil/app/src/main/java/com/example/bombavafrontmovil/GestorJuego.java
@@ -19,6 +19,8 @@ public class GestorJuego {
     final List<BarcoLogico> flota = new ArrayList<>();
     final String matchId;
     final String myUserId;
+
+    private boolean perspectivaFijada = false;
     final PartidaListener listener;
     final Map<String, UserShip> diccionarioFlota;
     final Map<String, UserShip> inventarioOriginal;
@@ -83,19 +85,23 @@ public class GestorJuego {
 
     public void recalcularPerspectiva(JSONArray myFleet, JSONArray enemyFleet) {
         try {
+            if (perspectivaFijada) {
+                return;
+            }
+
             if (myFleet == null || myFleet.length() == 0) {
                 return;
             }
 
             double mediaMy = mediaY(myFleet);
 
-            // La perspectiva depende solo de mi flota.
-            // Si mi flota está en la mitad superior lógica, invertimos para pintarla abajo.
+            // La perspectiva se calcula UNA sola vez al inicio de la partida
             invertirPerspectiva = mediaMy < 7.0;
+            perspectivaFijada = true;
 
             Log.d(
                     "DEBUG_PERSPECTIVA",
-                    "mediaMy=" + mediaMy +
+                    "PERSPECTIVA FIJADA -> mediaMy=" + mediaMy +
                             " invertir=" + invertirPerspectiva
             );
         } catch (Exception e) {


### PR DESCRIPTION
Se ha corregido un bug en el que la perspectiva se invertía cuando mas de la mitad de tus barcos estaban en la zona rival, este error se debía a que al principio el backend enviaba mal las posiciones y tuve que hacer algún apaño el cual seguía ahí y había que quitarlo para que fijase la perspectiva desde el inicio.